### PR TITLE
Add api errors

### DIFF
--- a/priv/api/en.json
+++ b/priv/api/en.json
@@ -1,0 +1,6 @@
+{
+  "invitations": {
+    "same_org": "This person already belongs to your organization.",
+    "other_org": "This user already belongs to an organization. Users can only belong to one organization."
+  }
+}


### PR DESCRIPTION
This is to add the errors for organization invites. The links I'm trying to resolve are: @res_translations_list()#/default/api/invitations/same_org
@res_translations_list()#/default/api/invitations/other_org
